### PR TITLE
fixed issue where body was meant to be stream instead of json

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/consul-mock-api.iml
+++ b/.idea/consul-mock-api.iml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="Go" enabled="true" />
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/consul-mock-api.iml" filepath="$PROJECT_DIR$/.idea/consul-mock-api.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/acl.go
+++ b/acl.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-func (m *Consul) ACLAuthMethodCreate(body *api.ACLAuthMethod, status int, reply *api.ACLAuthMethod) *mockapi.MockAPICall {
+func (m *Consul) ACLAuthMethodCreate(body []byte, status int, reply *api.ACLAuthMethod) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/acl/auth-method").WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -33,13 +33,13 @@ func (m *Consul) ACLAuthMethodList(status int, reply []*api.ACLAuthMethodListEnt
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLAuthMethodUpdate(authMethodName string, body *api.ACLAuthMethod, status int, reply *api.ACLAuthMethod) *mockapi.MockAPICall {
+func (m *Consul) ACLAuthMethodUpdate(authMethodName string, body []byte, status int, reply *api.ACLAuthMethod) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/acl/auth-method/%s", authMethodName)).WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLBindingRuleCreate(body *api.ACLBindingRule, status int, reply *api.ACLBindingRule) *mockapi.MockAPICall {
+func (m *Consul) ACLBindingRuleCreate(body []byte, status int, reply *api.ACLBindingRule) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/acl/binding-rule").WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -63,7 +63,7 @@ func (m *Consul) ACLBindingRuleList(status int, reply []*api.ACLBindingRule) *mo
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLBindingRuleUpdate(bindingRuleID string, body *api.ACLBindingRule, status int, reply *api.ACLBindingRule) *mockapi.MockAPICall {
+func (m *Consul) ACLBindingRuleUpdate(bindingRuleID string, body []byte, status int, reply *api.ACLBindingRule) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/acl/binding-rule/%s", bindingRuleID)).WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -75,7 +75,7 @@ func (m *Consul) ACLBootstrap(status int, reply *api.ACLToken) *mockapi.MockAPIC
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLLogin(body *api.ACLLoginParams, status int, reply *api.ACLToken) *mockapi.MockAPICall {
+func (m *Consul) ACLLogin(body []byte, status int, reply *api.ACLToken) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("POST", "/v1/acl/login").WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -87,7 +87,7 @@ func (m *Consul) ACLLogout(status int, reply interface{}) *mockapi.MockAPICall {
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLPolicyCreate(body *api.ACLPolicy, status int, reply *api.ACLPolicy) *mockapi.MockAPICall {
+func (m *Consul) ACLPolicyCreate(body []byte, status int, reply *api.ACLPolicy) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/acl/policy").WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -117,7 +117,7 @@ func (m *Consul) ACLPolicyList(status int, reply []*api.ACLPolicyListEntry) *moc
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLPolicyUpdate(policyID string, body *api.ACLPolicy, status int, reply *api.ACLPolicy) *mockapi.MockAPICall {
+func (m *Consul) ACLPolicyUpdate(policyID string, body []byte, status int, reply *api.ACLPolicy) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/acl/policy/%s", policyID)).WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -129,7 +129,7 @@ func (m *Consul) ACLReplication(status int, reply *api.ACLReplicationStatus) *mo
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLRoleCreate(body *api.ACLPolicy, status int, reply []*api.ACLRole) *mockapi.MockAPICall {
+func (m *Consul) ACLRoleCreate(body []byte, status int, reply []*api.ACLRole) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/acl/role").WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -159,7 +159,7 @@ func (m *Consul) ACLRoleList(status int, reply []*api.ACLRole) *mockapi.MockAPIC
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLRoleUpdate(roleID string, body *api.ACLRole, status int, reply *api.ACLRole) *mockapi.MockAPICall {
+func (m *Consul) ACLRoleUpdate(roleID string, body []byte, status int, reply *api.ACLRole) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/acl/role/%s", roleID)).WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -177,7 +177,7 @@ func (m *Consul) ACLRulesTranslateFromToken(tokenID string, status int, reply st
 	return m.WithTextReply(req, status, reply)
 }
 
-func (m *Consul) ACLTokenCreate(body *api.ACLToken, status int, reply []*api.ACLToken) *mockapi.MockAPICall {
+func (m *Consul) ACLTokenCreate(body []byte, status int, reply *api.ACLToken) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/acl/token").WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -207,7 +207,7 @@ func (m *Consul) ACLTokenSelf(headers map[string]string, queryParams map[string]
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) ACLTokenUpdate(tokenID string, body *api.ACLToken, status int, reply *api.ACLToken) *mockapi.MockAPICall {
+func (m *Consul) ACLTokenUpdate(tokenID string, body []byte, status int, reply *api.ACLToken) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/acl/token/%s", tokenID)).WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)

--- a/acl.json
+++ b/acl.json
@@ -12,7 +12,7 @@
     "ACLLogin": {
       "Path": "/v1/acl/login",
       "Method": "POST",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLLoginParams",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLToken"
@@ -37,7 +37,7 @@
     "ACLPolicyCreate": {
       "Path": "/v1/acl/policy",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLPolicy",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLPolicy"
@@ -54,7 +54,7 @@
     "ACLPolicyUpdate": {
       "Path": "/v1/acl/policy/%s",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLPolicy",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLPolicy",
@@ -88,7 +88,7 @@
     "ACLRoleCreate": {
       "Path": "/v1/acl/role",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLPolicy",
       "ResponseFormat": "json",
       "ResponseType": "[]*api.ACLRole"
@@ -105,7 +105,7 @@
     "ACLRoleUpdate": {
       "Path": "/v1/acl/role/%s",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLRole",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLRole",
@@ -139,7 +139,7 @@
     "ACLBindingRuleCreate": {
       "Path": "/v1/acl/binding-rule",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLBindingRule",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLBindingRule"
@@ -156,7 +156,7 @@
     "ACLBindingRuleUpdate": {
       "Path": "/v1/acl/binding-rule/%s",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLBindingRule",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLBindingRule",
@@ -181,7 +181,7 @@
     "ACLAuthMethodCreate": {
       "Path": "/v1/acl/auth-method",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLAuthMethod",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLAuthMethod"
@@ -198,7 +198,7 @@
     "ACLAuthMethodUpdate": {
       "Path": "/v1/acl/auth-method/%s",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLAuthMethod",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLAuthMethod",
@@ -236,10 +236,10 @@
     "ACLTokenCreate": {
       "Path": "/v1/acl/token",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLToken",
       "ResponseFormat": "json",
-      "ResponseType": "[]*api.ACLToken"
+      "ResponseType": "*api.ACLToken"
     },
     "ACLTokenGet": {
       "Path": "/v1/acl/token/%s",
@@ -261,7 +261,7 @@
     "ACLTokenUpdate": {
       "Path": "/v1/acl/token/%s",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.ACLToken",
       "ResponseFormat": "json",
       "ResponseType": "*api.ACLToken",

--- a/agent.go
+++ b/agent.go
@@ -4,10 +4,10 @@ package mockconsul
 
 import (
 	"fmt"
+	mockapi "github.com/mkeeler/mock-http-api"
 	"io"
 
 	"github.com/hashicorp/consul/api"
-	mockapi "github.com/mkeeler/mock-http-api"
 )
 
 func (m *Consul) AgentCheckDeregister(checkID string, status int) *mockapi.MockAPICall {
@@ -16,13 +16,13 @@ func (m *Consul) AgentCheckDeregister(checkID string, status int) *mockapi.MockA
 	return m.WithNoResponseBody(req, status)
 }
 
-func (m *Consul) AgentCheckRegister(body *api.AgentCheckRegistration, status int) *mockapi.MockAPICall {
+func (m *Consul) AgentCheckRegister(body []byte, status int) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/agent/check/register").WithBody(body)
 
 	return m.WithNoResponseBody(req, status)
 }
 
-func (m *Consul) AgentCheckUpdateTLL(checkID string, body map[string]interface{}, status int) *mockapi.MockAPICall {
+func (m *Consul) AgentCheckUpdateTLL(checkID string, body []byte, status int) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/agent/check/update/%s", checkID)).WithBody(body)
 
 	return m.WithNoResponseBody(req, status)
@@ -34,7 +34,7 @@ func (m *Consul) AgentChecks(status int, reply map[string]*api.AgentCheck) *mock
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) AgentConnectAuthorize(body *api.AgentAuthorizeParams, status int) *mockapi.MockAPICall {
+func (m *Consul) AgentConnectAuthorize(body []byte, status int) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("POST", "/v1/agent/connect/authorize").WithBody(body)
 
 	return m.WithNoResponseBody(req, status)
@@ -142,7 +142,7 @@ func (m *Consul) AgentServiceMaintenance(serviceID string, status int) *mockapi.
 	return m.WithNoResponseBody(req, status)
 }
 
-func (m *Consul) AgentServiceRegister(body *api.AgentServiceRegistration, status int) *mockapi.MockAPICall {
+func (m *Consul) AgentServiceRegister(body []byte, status int) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/agent/service/register").WithBody(body)
 
 	return m.WithNoResponseBody(req, status)

--- a/agent.json
+++ b/agent.json
@@ -64,7 +64,7 @@
       "Path": "/v1/agent/service/register",
       "Method": "PUT",
       "QueryParameters": true,
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.AgentServiceRegistration"
     },
     "AgentServiceDeregister": {
@@ -82,12 +82,12 @@
       "Path": "/v1/agent/check/update/%s",
       "Method": "PUT",
       "PathParameters": ["checkID"],
-      "BodyFormat": "json"
+      "BodyFormat": "stream"
     },
     "AgentCheckRegister": {
       "Path": "/v1/agent/check/register",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.AgentCheckRegistration"
     },
     "AgentCheckDeregister": {
@@ -114,7 +114,7 @@
     "AgentConnectAuthorize": {
       "Path": "/v1/agent/connect/authorize",
       "Method": "POST",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.AgentAuthorizeParams"
     },
     "AgentConnectCARoots": {

--- a/catalog.go
+++ b/catalog.go
@@ -21,7 +21,7 @@ func (m *Consul) CatalogDatacenters(status int, reply []string) *mockapi.MockAPI
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) CatalogDeregister(body *api.CatalogRegistration, status int, reply interface{}) *mockapi.MockAPICall {
+func (m *Consul) CatalogDeregister(body []byte, status int, reply interface{}) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/catalog/deregister").WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)
@@ -51,7 +51,7 @@ func (m *Consul) CatalogNodes(status int, reply []*api.Node) *mockapi.MockAPICal
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) CatalogRegister(body *api.CatalogRegistration, status int, reply interface{}) *mockapi.MockAPICall {
+func (m *Consul) CatalogRegister(body []byte, status int, reply interface{}) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", "/v1/catalog/register").WithBody(body)
 
 	return m.WithJSONReply(req, status, reply)

--- a/catalog.json
+++ b/catalog.json
@@ -6,14 +6,14 @@
     "CatalogRegister": {
       "Path": "/v1/catalog/register",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.CatalogRegistration",
       "ResponseFormat": "json"
     },
     "CatalogDeregister": {
       "Path": "/v1/catalog/deregister",
       "Method": "PUT",
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.CatalogRegistration",
       "ResponseFormat": "json"
     },

--- a/examples/token_create.go
+++ b/examples/token_create.go
@@ -1,0 +1,57 @@
+package examples
+
+import (
+	"bytes"
+	"encoding/json"
+	"github.com/hashicorp/consul/api"
+	mockconsul "github.com/mkeeler/consul-mock-api"
+	"reflect"
+	"testing"
+)
+
+func TestTokenCreate(t *testing.T) {
+	m := mockconsul.NewConsul(t)
+	defer m.Close()
+
+	m.SetFilteredHeaders([]string{
+		"Accept-Encoding",
+		"User-Agent",
+		"Content-Length",
+		"Content-Type",
+	})
+
+	// this body will be checked and compared to the body that is sent to the request
+	body := &api.ACLToken{
+		AccessorID:  "cd45b25a-07cf-4a60-ae71-2a227eaace8e",
+		SecretID:    "cd45b25a-07cf-4a60-ae71-2a227eaace8e",
+		Description: "test token",
+	}
+
+	// Convert the body into a slice of bytes.
+	// You must use the json encoder as it appends a newline to the end of the slice.
+	buf := bytes.NewBuffer(nil)
+	enc := json.NewEncoder(buf)
+	if err := enc.Encode(body); err != nil {
+		t.FailNow()
+	}
+
+	// mock the call to PUT /v1/acl/token
+	m.ACLTokenCreate(buf.Bytes(), 200, body).Once() // expect one call to this endpoint
+
+	cfg := api.DefaultConfig()
+	cfg.Address = m.URL()
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("error when creating a new HTTP client: %v", err)
+	}
+
+	token, _, err := client.ACL().TokenCreate(body, nil)
+	if err != nil {
+		t.Fatalf("failed to get get token: %v", err)
+	}
+
+	if !reflect.DeepEqual(token, body) {
+		t.Fatal("ACL token got from endpoint does not match expected result")
+	}
+}

--- a/examples/token_list.go
+++ b/examples/token_list.go
@@ -1,0 +1,52 @@
+package examples
+
+import (
+	"testing"
+
+	"github.com/hashicorp/consul/api"
+	mockconsul "github.com/mkeeler/consul-mock-api"
+)
+
+func TestTokenList(t *testing.T) {
+	m := mockconsul.NewConsul(t)
+	defer m.Close()
+
+	// http.Get will add both of the headers, but we don't want to care about them.
+	m.SetFilteredHeaders([]string{
+		"Accept-Encoding",
+		"User-Agent",
+	})
+
+	// set up an expectation for a GET /v1/acl/tokens
+	m.ACLTokenList(200, []*api.ACLTokenListEntry{
+		{
+			CreateIndex: 1,
+			ModifyIndex: 2,
+			AccessorID:  "cd45b25a-07cf-4a60-ae71-2a227eaace8e",
+			Description: "fake token",
+			NodeIdentities: []*api.ACLNodeIdentity{
+				{
+					NodeName:   "foo",
+					Datacenter: "dc1",
+				},
+			},
+		},
+	}).Once() // expect this call to be made exactly once
+
+	cfg := api.DefaultConfig()
+	cfg.Address = m.URL()
+
+	client, err := api.NewClient(cfg)
+	if err != nil {
+		t.Fatalf("error when creating a new HTTP client: %v", err)
+	}
+
+	tokens, _, err := client.ACL().TokenList(nil)
+	if err != nil {
+		t.Fatalf("error when retrieving token list: %v", err)
+	}
+
+	if len(tokens) != 1 {
+		t.Fatalf("wrong number of token returned - expected: 1, got: %d", len(tokens))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,19 +1,27 @@
 module github.com/mkeeler/consul-mock-api
 
-go 1.14
+go 1.19
+
+require (
+	github.com/hashicorp/consul/api v1.12.0
+	github.com/mkeeler/mock-http-api v0.0.0-20201203162141-a6b0fbe0e72b
+)
 
 require (
 	github.com/armon/go-metrics v0.3.11 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/fatih/color v1.13.0 // indirect
-	github.com/hashicorp/consul/api v1.12.0
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-hclog v1.2.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
+	github.com/hashicorp/go-rootcerts v1.0.2 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/hashicorp/serf v0.9.7 // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
-	github.com/mkeeler/mock-http-api v0.0.0-20201203162141-a6b0fbe0e72b
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.7.1 // indirect
 	golang.org/x/sys v0.0.0-20220422013727-9388b58f7150 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,7 +173,6 @@ golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/kv.go
+++ b/kv.go
@@ -9,19 +9,19 @@ import (
 	"github.com/hashicorp/consul/api"
 )
 
-func (m *Consul) KVAcquire(key string, queryParams map[string]string, body *api.KVPair, status int, reply bool) *mockapi.MockAPICall {
+func (m *Consul) KVAcquire(key string, queryParams map[string]string, body []byte, status int, reply bool) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/kv/%s", key)).WithBody(body).WithQueryParams(queryParams)
 
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) KVDelete(key string, queryParams map[string]string, body *api.KVPair, status int) *mockapi.MockAPICall {
+func (m *Consul) KVDelete(key string, queryParams map[string]string, body []byte, status int) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("DELETE", fmt.Sprintf("/v1/kv/%s", key)).WithBody(body).WithQueryParams(queryParams)
 
 	return m.WithNoResponseBody(req, status)
 }
 
-func (m *Consul) KVDeleteCAS(key string, queryParams map[string]string, body *api.KVPair, status int, reply bool) *mockapi.MockAPICall {
+func (m *Consul) KVDeleteCAS(key string, queryParams map[string]string, body []byte, status int, reply bool) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("DELETE", fmt.Sprintf("/v1/kv/%s", key)).WithBody(body).WithQueryParams(queryParams)
 
 	return m.WithJSONReply(req, status, reply)
@@ -45,19 +45,19 @@ func (m *Consul) KVList(prefix string, queryParams map[string]string, status int
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) KVPut(key string, queryParams map[string]string, body *api.KVPair, status int) *mockapi.MockAPICall {
+func (m *Consul) KVPut(key string, queryParams map[string]string, body []byte, status int) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/kv/%s", key)).WithBody(body).WithQueryParams(queryParams)
 
 	return m.WithNoResponseBody(req, status)
 }
 
-func (m *Consul) KVPutCAS(key string, queryParams map[string]string, body *api.KVPair, status int, reply bool) *mockapi.MockAPICall {
+func (m *Consul) KVPutCAS(key string, queryParams map[string]string, body []byte, status int, reply bool) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/kv/%s", key)).WithBody(body).WithQueryParams(queryParams)
 
 	return m.WithJSONReply(req, status, reply)
 }
 
-func (m *Consul) KVRelease(key string, queryParams map[string]string, body *api.KVPair, status int, reply bool) *mockapi.MockAPICall {
+func (m *Consul) KVRelease(key string, queryParams map[string]string, body []byte, status int, reply bool) *mockapi.MockAPICall {
 	req := mockapi.NewMockRequest("PUT", fmt.Sprintf("/v1/kv/%s", key)).WithBody(body).WithQueryParams(queryParams)
 
 	return m.WithJSONReply(req, status, reply)

--- a/kv.json
+++ b/kv.json
@@ -32,7 +32,7 @@
       "Method": "PUT",
       "PathParameters": ["key"],
       "QueryParams": true,
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.KVPair"
     },
     "KVPutCAS": {
@@ -40,7 +40,7 @@
       "Method": "PUT",
       "PathParameters": ["key"],
       "QueryParams": true,
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.KVPair",
       "ResponseFormat": "json",
       "ResponseType": "bool"
@@ -50,7 +50,7 @@
       "Method": "PUT",
       "PathParameters": ["key"],
       "QueryParams": true,
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.KVPair",
       "ResponseFormat": "json",
       "ResponseType": "bool"
@@ -60,7 +60,7 @@
       "Method": "PUT",
       "PathParameters": ["key"],
       "QueryParams": true,
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.KVPair",
       "ResponseFormat": "json",
       "ResponseType": "bool"
@@ -70,7 +70,7 @@
       "Method": "DELETE",
       "PathParameters": ["key"],
       "QueryParams": true,
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.KVPair"
     },
     "KVDeleteCAS": {
@@ -78,7 +78,7 @@
       "Method": "DELETE",
       "PathParameters": ["key"],
       "QueryParams": true,
-      "BodyFormat": "json",
+      "BodyFormat": "stream",
       "BodyType": "*api.KVPair",
       "ResponseFormat": "json",
       "ResponseType": "bool"


### PR DESCRIPTION
Related to issue https://github.com/mkeeler/consul-mock-api/issues/6

After running some tests, it looks like the `BodyType` of `json` was not correct for most API calls that have a body.

I went ahead and replaced all instances of `json` to `stream` on requests that have bodies, along with including an example on how to use a mocked API call with a body.

let me know if there's any other issues that need to be fixed